### PR TITLE
allow and document protecting global function names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,11 @@ function::
 
     $c['random'] = $c->protect(function () { return rand(); });
 
+When you want to set the the value of a parameter to an existing (global)
+function name, you must also protect it. For example::
+
+    $container['log_function'] = $container->protect('var_dump');
+
 Packaging a Container for reusability
 -------------------------------------
 

--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -116,7 +116,7 @@ class Pimple implements ArrayAccess
      *
      * @return Closure The protected closure
      */
-    function protect(\Closure $callable)
+    function protect($callable)
     {
         return function ($c) use ($callable)
         {

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -134,4 +134,11 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($callback, $pimple['protected']);
     }
+
+    public function testProtectGlobalFunctionName()
+    {
+        $pimple = new Pimple();
+        $pimple['global_function'] = $pimple->protect('strlen');
+        $this->assertSame('strlen', $pimple['global_function']);
+    }
 }


### PR DESCRIPTION
when a parameter's value is a valid callable (eg. name
of an existing global function) it must also be protected.

See issue #8.
