### PR TITLE
Enforce services to be closures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,11 +74,6 @@ function::
 
     $c['random'] = $c->protect(function () { return rand(); });
 
-When you want to set the the value of a parameter to an existing (global)
-function name, you must also protect it. For example::
-
-    $container['log_function'] = $container->protect('var_dump');
-
 Packaging a Container for reusability
 -------------------------------------
 

--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -60,7 +60,7 @@ class Pimple implements ArrayAccess
             throw new InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
         }
 
-        return is_callable($this->values[$id]) ? $this->values[$id]($this) : $this->values[$id];
+        return $this->values[$id] instanceof Closure ? $this->values[$id]($this) : $this->values[$id];
     }
 
     /**
@@ -93,7 +93,7 @@ class Pimple implements ArrayAccess
      *
      * @return Closure The wrapped closure
      */
-    function share(\Closure $callable)
+    function share(Closure $callable)
     {
         return function ($c) use ($callable)
         {
@@ -116,7 +116,7 @@ class Pimple implements ArrayAccess
      *
      * @return Closure The protected closure
      */
-    function protect($callable)
+    function protect(Closure $callable)
     {
         return function ($c) use ($callable)
         {

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -135,10 +135,10 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($callback, $pimple['protected']);
     }
 
-    public function testProtectGlobalFunctionName()
+    public function testGlobalFunctionNameAsParameterValue()
     {
         $pimple = new Pimple();
-        $pimple['global_function'] = $pimple->protect('strlen');
+        $pimple['global_function'] = 'strlen';
         $this->assertSame('strlen', $pimple['global_function']);
     }
 }


### PR DESCRIPTION
As was discussed in issue #8, having any _callable_ value be a service leads
to issues, because function names are callable. Thus any parameter value
that is a global function name would have to be protected.

The easiest solution is to only treat closures as services, and treat
everything else as a parameter. This is actually the expected behavior,
according to the documentation.

---

I was unsure how to document this change, because all the docs specify services as closures. If you still think it should be noted, where?
