### PR TITLE
Parameterized Factory Methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,22 @@ Using the defined objects is also very easy::
     // $storage = new SessionStorage('SESSION_ID');
     // $session = new Session($storage);
 
+Passing Arguments to Objects
+----------------------------
+
+If the anonymous function requires arguments that aren't in the container,
+wrap it with the ``factory()`` method. Call the object returned by the container
+as you would a normal method and pass the desired values to it::
+
+    // define the factory method
+    $container['log.path'] = __DIR__ . '/logs/';
+    $container['log'] = $container->factory(function ($c, $subsystem) {
+        return new Logger($c['log.path'] . $subsystem . '.log');
+    });
+
+    // get the mail logger
+    $log = $container['log']('mail');
+
 Defining Shared Objects
 -----------------------
 

--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -113,6 +113,32 @@ class Pimple implements ArrayAccess
     }
 
     /**
+     * Returns a closure that wraps the given factory method closure to prepend
+     * the container as the first argument.
+     *
+     * @param Closure $callable A closure to use as a factory method
+     *
+     * @return Closure The wrapped closure
+     */
+    function factory(Closure $callable)
+    {
+        return function ($c) use ($callable) {
+            static $factory;
+
+            if (is_null($factory)) {
+                $factory = function () use ($c, $callable) {
+                    $args = func_get_args();
+                    array_unshift($args, $c);
+
+                    return call_user_func_array($callable, $args);
+                };
+            }
+
+            return $factory;
+        };
+    }
+
+    /**
      * Protects a callable from being interpreted as a service.
      *
      * This is useful when you want to store a callable as a parameter.

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -135,6 +135,17 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($callback, $pimple['protected']);
     }
 
+    public function testFactory()
+    {
+        $pimple = new Pimple();
+        $callback = function ($c, $y) { return $c['x'] + $y; };
+        $pimple['x'] = 5;
+        $pimple['factory'] = $pimple->factory($callback);
+
+        $this->assertNotSame($callback, $pimple['factory']);
+        $this->assertEquals(7, $pimple['factory'](2));
+    }
+
     public function testGlobalFunctionNameAsParameterValue()
     {
         $pimple = new Pimple();


### PR DESCRIPTION
This commit implements the feature request I made in #13. While the example I gave is pretty simplistic, in my actual code I need to pass objects from the container and parameters not in the container to a constructor.

Note that this new method isn't really needed per se. You could have the factory method reference the global container, but the pattern in Pimple is always to pass the container to the factory method, and that's what this feature allows.
