### PR TITLE
Added constructor arguments.

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -32,7 +32,19 @@
  */
 class Pimple implements ArrayAccess
 {
-    private $values = array();
+    private $values;
+
+    /**
+     * Instantiate the container.
+     *
+     * Objects and parameters can be passed as argument to the constructor.
+     *
+     * @param array $values The parameters or objects.
+     */
+    function __construct (array $values = array())
+    {
+        $this->values = $values;
+    }
 
     /**
      * Sets a parameter or an object.

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -97,6 +97,14 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($pimple['non_existent']));
     }
 
+    public function testConstructorInjection ()
+    {
+        $params = array("param" => "value");
+        $pimple = new Pimple($params);
+
+        $this->assertSame($params['param'], $pimple['param']);
+    }
+
     /**
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Identifier "foo" is not defined.


### PR DESCRIPTION
When creating dedicated containers with only a handful of parameters it can be nice to have constructor injection.

``` php
<?php

$pimple = new Pimple(array('secret' => 'fabp0t'));
```
