### PR TITLE
Adds extend method, allowing users to extend/customise object Closures

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -179,6 +179,11 @@ class Pimple implements ArrayAccess
         }
 
         $factory = $this->values[$id];
+
+        if (!($factory instanceof Closure)) {
+            throw new InvalidArgumentException(sprintf('Identifier "%s" does not contain an object definition.', $id));
+        }
+
         return $this->values[$id] = function ($c) use ($callable, $factory) {
             return $callable($factory($c), $c);
         };

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -215,4 +215,25 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($serviceOne, $serviceTwo);
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Identifier "foo" is not defined.
+     */
+    public function testExtendValidatesKeyIsPresent()
+    {
+        $pimple = new Pimple();
+        $pimple->extend('foo', function () {});
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Identifier "foo" does not contain an object definition.
+     */
+    public function testExtendValidatesKeyYieldsObjectDefinition()
+    {
+        $pimple = new Pimple();
+        $pimple['foo'] = 123;
+        $pimple->extend('foo', function () {});
+    }
 }


### PR DESCRIPTION
Kind of like an after filter for objects.

Use case:

Third party code is used to register an object, user wishes to add method calls to the definition, without loading it before it is actually required.

e.g. Add a custom loader to the Twig Service when using Silex

``` php
<?php

$app->register(new Silex\Provider\TwigServiceProvider(), array(
    'twig.path'       => __DIR__.'/views',
    'twig.class_path' => __DIR__.'/vendor/twig/lib',
));

$app->extend('twig', function($twig, $c) {
    $twig->addLoader($c['my.custom.loader']);
    return $twig;
});

```

I thought about returning a Closure and the user having to reassign it to maintain consistency with the existing API, like:

``` php
<?php

$app['twig'] = $app->extend('twig', function($twig, $c) {
    $twig->addLoader($c['my.custom.loader']);
    return $twig;
});
```

But I can't think of a use case where you wouldn't want to assign it, so made the assignment part of the method.

Another option I considered would be to not require the original object to be returned in the extending Closure, but that would prevent people using decorators and such.
