### PR TITLE
Added the branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     },
     "autoload": {
         "psr-0": { "Pimple": "lib/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows other packages to depend on Pimple `1.0.*` instead of having to depend on `*` or `dev-master` (which are unbound constraints and so should never be used in tags as they assume we know the future)
