### PR TITLE
Show all registered services

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -32,7 +32,7 @@
  */
 class Pimple implements ArrayAccess
 {
-    private $values;
+    protected $values;
 
     /**
      * Instantiate the container.


### PR DESCRIPTION
Hello,

i have extended the Pimple class to use the singleton pattern. I want to write a simple symfony 1.4 task to display all service ids, but i can't access the values property in my extended class, because the property is private.

There are two possibilities: 
1. change the access of values to protected
2. add a method in Pimple class to return the array_keys of $values

What would you prefer?
