### PR TITLE
Removed extends of Services

### DIFF
--- a/tests/Pimple/Tests/Service.php
+++ b/tests/Pimple/Tests/Service.php
@@ -34,6 +34,6 @@ use Pimple;
  * @package pimple
  * @author  Igor Wiedler <igor@wiedler.ch>
  */
-class Service extends \PHPUnit_Framework_TestCase
+class Service
 {
 }


### PR DESCRIPTION
`Pimple\Tests\Service` does not extends  `\PHPUnit_Framework_TestCase`
anymore, as i not needed
