### PR TITLE
Remove version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
     "keywords": ["dependency injection", "container"],
     "homepage": "http://pimple.sensiolabs.org",
-    "version": "1.0.0",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Currently Composer recognises the master branch as being a stable release.
