### PR TITLE
Uses call_user_func instead of current syntax

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -78,7 +78,7 @@ class Pimple implements ArrayAccess
             throw new InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
         }
 
-        return $this->values[$id] instanceof Closure ? $this->values[$id]($this) : $this->values[$id];
+        return $this->values[$id] instanceof Closure ? call_user_func($this->values[$id], $this) : $this->values[$id];
     }
 
     /**


### PR DESCRIPTION
This was causing errors in PHPStorm saying "expected colon". I think
PHPStorm doesn't understand the Closure syntax properly yet. Just to
prevent seeing the errors I changed it to the call_user_func method. Did
not affect my project, but I haven't fully bug tested this. Also don't
know if this introduces performance concerns because of function call.
