### PR TITLE
Initialize property for serializers

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -32,7 +32,7 @@
  */
 class Pimple implements ArrayAccess
 {
-    private $values;
+    private $values = array();
 
     /**
      * Instantiate the container.


### PR DESCRIPTION
Serializers and test frameworks skip the constructor using
serialization tricks. This means that if an empty Pimple instance is
serialized and later deserialized that the $values property contains
'null'. This breaks offsetExists() and several other locations that 
assume the $values property contains an array.
