### PR TITLE
Support for invokables and not just Closures

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -220,7 +220,7 @@ class Pimple implements ArrayAccess
      *
      * @throws InvalidArgumentException
      */
-    protected static function expectFactory($value, $error = 'Expected an invokable object.')
+    public static function expectFactory($value, $error = 'Expected an invokable object.')
     {
         $args = array_slice(func_get_args(), 2);
 


### PR DESCRIPTION
Continuation of #59
## 

Use an `isFactory` and `expectFactory` method instead of `Closure` type hinting, and some refactoring.
