### PR TITLE
Introduce static versions of share() and protect()

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -106,18 +106,6 @@ class Pimple implements ArrayAccess
     }
 
     /**
-     * Alias of shareStatic.
-     *
-     * @param Closure $callable A closure to wrap for uniqueness
-     *
-     * @return Closure The wrapped closure
-     */
-    public function share(Closure $callable)
-    {
-        return static::shareStatic($callable);
-    }
-
-    /**
      * Returns a closure that stores the result of the given closure for
      * uniqueness in the scope of this instance of Pimple.
      *
@@ -125,7 +113,7 @@ class Pimple implements ArrayAccess
      *
      * @return Closure The wrapped closure
      */
-    public static function shareStatic(Closure $callable)
+    public static function share(Closure $callable)
     {
         return function ($c) use ($callable) {
             static $object;
@@ -139,18 +127,6 @@ class Pimple implements ArrayAccess
     }
 
     /**
-     * Alias of protectStatic.
-     *
-     * @param Closure $callable A closure to protect from being evaluated
-     *
-     * @return Closure The protected closure
-     */
-    public function protect(Closure $callable)
-    {
-        return static::protectStatic($callable);
-    }
-
-    /**
      * Protects a callable from being interpreted as a service.
      *
      * This is useful when you want to store a callable as a parameter.
@@ -159,7 +135,7 @@ class Pimple implements ArrayAccess
      *
      * @return Closure The protected closure
      */
-    public static function protectStatic(Closure $callable)
+    public static function protect(Closure $callable)
     {
         return function ($c) use ($callable) {
             return $callable;


### PR DESCRIPTION
I have a use case where I want to be able to pass parameters to an object that will then at some point create and initialize a pimple container. Then set the parameters. I want to be able to override defaults, including services.

Essentially, this:

```
createContainer([
    'foo' => Pimple::shareStatic(function () { return new Foo(); }),
]);
```

Since the container does not exist yet, I have no instance to call share() on. Therefore, I want static versions of share and protect, so that this use case is supported properly.

I'm open to:
- Removing the docblocks on the static versions
- Finding better names for the static versions
- Just making the existing `share` and `protect` methods static and abuse the fact that PHP allows them to be called dynamically as well
