### PR TITLE
Alternative to PR #61

### DIFF
--- a/tests/Pimple/Tests/Invokable.php
+++ b/tests/Pimple/Tests/Invokable.php
@@ -28,8 +28,11 @@ namespace Pimple\Tests;
 
 class Invokable
 {
-    public function __invoke()
+    public function __invoke($value = null)
     {
-        return 'I was invoked';
+        $service = new Service();
+        $service->value = $value;
+
+        return $service;
     }
 }


### PR DESCRIPTION
This PR is a continuation of a419262.  It allows invokable objects to be shared, extended, and protected.  The unit tests have been updated (where applicable) to use data providers to ensure that invokable objects work in all situations where Closures work.

Unlike #61, this PR contains no major refactoring.
