### PR TITLE
Allow to extend a service which is not defined yet.

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -173,12 +173,14 @@ class Pimple implements ArrayAccess
      */
     public function extend($id, Closure $callable)
     {
-        return $this->values[$id] = function ($c) use ($callable, $id) {
-            if (!array_key_exists($id, $this->values)) {
+        $that = $this;
+        
+        return $this->values[$id] = function ($c) use ($callable, $id, $that) {
+            if (!array_key_exists($id, $that->values)) {
                 throw new InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
             }
 
-            $factory = $this->values[$id];
+            $factory = $that->values[$id];
 
             if (!($factory instanceof Closure)) {
                 throw new InvalidArgumentException(sprintf('Identifier "%s" does not contain an object definition.', $id));


### PR DESCRIPTION
I'm confronted with a case where I must extend a service which is not definied yet (when all services are set directly in an array in the constructor for exemple). In one hand, I think it's a good thing to forbid to extend a service which doesn't exist, but in the other hand, according to the Pimple documentation, "the order of the definitions does not matter". So I propose this PR that move the check of the identifier (exist and is callable) from the extend method to the extended closure.
