### PR TITLE
Throw an exception when a shared service has a circular reference

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -117,9 +117,16 @@ class Pimple implements ArrayAccess
     {
         return function ($c) use ($callable) {
             static $object;
+            static $loading;
 
             if (null === $object) {
+                if (true === $loading) {
+                    throw new \LogicException('A shared service has a circular reference to itself. You must fix your service dependencies.');
+                }
+
+                $loading = true;
                 $object = $callable($c);
+                $loading = null;
             }
 
             return $object;

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -154,6 +154,18 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($serviceOne, $serviceTwo);
     }
 
+    /**
+     * @expectedException \LogicException
+     */
+    public function testShareThrowExeptionForInfiniteLoops()
+    {
+        $pimple = new Pimple();
+        $pimple['looping'] = $pimple->share(function ($pimple) {
+            $pimple['looping'];
+        });
+        $pimple['looping'];
+    }
+
     public function testProtect()
     {
         $pimple = new Pimple();


### PR DESCRIPTION
With Pimple, it's easy to create services with a circular reference. This PR adds an exception to break before the infinite loop.

Unfortunately, it's not possible to get the name of the service.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Symfony DI throws a similar exception : 
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ContainerBuilder.php#L475
