### PR TITLE
Detect circular references and throw a LogicException (replaces #73)

### DIFF
--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -122,6 +122,40 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($pimple['foo']);
     }
 
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage The service "looping" has a circular reference to itself.
+     */
+    public function testOffsetGetDetectCircularReference()
+    {
+        $pimple = new Pimple();
+        $pimple['looping'] = function ($pimple) {
+            $pimple['looping'];
+        };
+        $pimple['looping'];
+    }
+
+    public function testOffsetGetLetFactoryExceptions()
+    {
+        $pimple = new Pimple();
+        $exception = new \RuntimeException('failed');
+        $pimple['failing'] = function () use ($exception) {
+            throw $exception;
+        };
+
+        try {
+            $pimple['failing'];
+        } catch (\RuntimeException $e) {
+            $this->assertSame($exception, $e);
+        }
+
+        try {
+            $pimple['failing'];
+        } catch (\RuntimeException $e) {
+            $this->assertSame($exception, $e);
+        }
+    }
+
     public function testUnset()
     {
         $pimple = new Pimple();


### PR DESCRIPTION
With Pimple, it's easy to create services with a circular reference. This PR replaces #73 with the ability to throw an exception for any type of "factory" (shared service or not) and display the service name in the exception. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This code is inspired by Symfony DI: 
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ContainerBuilder.php#L475
