### PR TITLE
[2.0] changed services to be shared by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,17 +58,6 @@ Using the defined services is also very easy::
     // $storage = new SessionStorage('SESSION_ID');
     // $session = new Session($storage);
 
-Defining Shared Services
-------------------------
-
-By default, each time you get a service, Pimple returns a new instance of it.
-If you want the same instance to be returned for all calls, wrap your
-anonymous function with the ``share()`` method::
-
-    $container['session'] = $container->share(function ($c) {
-        return new Session($c['session_storage']);
-    });
-
 Protecting Parameters
 ---------------------
 
@@ -98,19 +87,6 @@ The first argument is the name of the object, the second is a function that
 gets access to the object instance and the container. The return value is
 a service definition, so you need to re-assign it on the container.
 
-If the service you plan to extend is already shared, it's recommended that you
-re-wrap your extended service with the ``shared`` method, otherwise your extension
-code will be called every time you access the service::
-
-    $container['twig'] = $container->share(function ($c) {
-        return new Twig_Environment($c['twig.loader'], $c['twig.options']);
-    });
-
-    $container['twig'] = $container->share($container->extend('twig', function ($twig, $c) {
-        $twig->addExtension(new MyTwigExtension());
-        return $twig;
-    }));
-
 Fetching the service creation function
 --------------------------------------
 
@@ -118,9 +94,9 @@ When you access an object, Pimple automatically calls the anonymous function
 that you defined, which creates the service object for you. If you want to get
 raw access to this function, you can use the ``raw()`` method::
 
-    $container['session'] = $container->share(function ($c) {
+    $container['session'] = function ($c) {
         return new Session($c['session_storage']);
-    });
+    };
 
     $sessionFunction = $container->raw('session');
 
@@ -148,12 +124,23 @@ Using this container from your own is as easy as it can get::
     // ...
 
     // embed the SomeContainer container
-    $container['embedded'] = $container->share(function () { return new SomeContainer(); });
+    $container['embedded'] = function () { return new SomeContainer(); };
 
     // configure it
     $container['embedded']['parameter'] = 'bar';
 
     // use it
     $container['embedded']['object']->...;
+
+Defining Prototype Services
+---------------------------
+
+By default, each time you get a service, Pimple returns the **same instance**
+of it. If you want a different instance to be returned for all calls, wrap your
+anonymous function with the ``prototype()`` method::
+
+    $container['session'] = $container->prototype(function ($c) {
+        return new Session($c['session_storage']);
+    });
 
 .. _Download it: https://github.com/fabpot/Pimple

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -57,9 +57,9 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testServicesShouldBeDifferent()
     {
         $pimple = new Pimple();
-        $pimple['service'] = function () {
+        $pimple['service'] = $pimple->prototype(function () {
             return new Service();
-        };
+        });
 
         $serviceOne = $pimple['service'];
         $this->assertInstanceOf('Pimple\Tests\Service', $serviceOne);
@@ -144,7 +144,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testShare($service)
     {
         $pimple = new Pimple();
-        $pimple['shared_service'] = $pimple->share($service);
+        $pimple['shared_service'] = $service;
 
         $serviceOne = $pimple['shared_service'];
         $this->assertInstanceOf('Pimple\Tests\Service', $serviceOne);
@@ -176,7 +176,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testRaw()
     {
         $pimple = new Pimple();
-        $pimple['service'] = $definition = function () { return 'foo'; };
+        $pimple['service'] = $definition = $pimple->prototype(function () { return 'foo'; });
         $this->assertSame($definition, $pimple->raw('service'));
     }
 
@@ -203,9 +203,9 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testExtend($service)
     {
         $pimple = new Pimple();
-        $pimple['shared_service'] = $pimple->share(function () {
+        $pimple['shared_service'] = function () {
             return new Service();
-        });
+        };
 
         $pimple->extend('shared_service', $service);
 
@@ -261,10 +261,10 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Service definition is not a Closure or invokable object.
      */
-    public function testShareFailsForInvalidServiceDefinitions($service)
+    public function testPrototypeFailsForInvalidServiceDefinitions($service)
     {
         $pimple = new Pimple();
-        $pimple->share($service);
+        $pimple->prototype($service);
     }
 
     /**


### PR DESCRIPTION
Now that we have several years of experience using Pimple, I think everyone agrees that having to call `share` everytime you need to define a service is cumbersome. And it is even error-prone when calling `extend` as one needs to call `share` again.
#62 proposes a shortcut for the extend use case, but I want to go one step further in Pimple 2.0: remove the need to call `share` altogether.

The reasoning is quite simple: services are 99.9% shared (I don't even have an example for a prototype service).

So, this PR makes closure shared by default. If you need to define a prototype service, call `prototype`.

This change is almost backward compatible as the `share` method is kept as a no-op method. The only BC break is if you have a prototype service in which case you need to wrap it with a `prototype` call.

Of course, Pimple 2.0 will be used in Silex 2.0, which will make things much easier to read and shorter.

TODO:
- [x] update docs and website for 2.0
