### PR TITLE
[2.0] renamed prototype to factory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,14 +132,14 @@ Using this container from your own is as easy as it can get::
     // use it
     $container['embedded']['object']->...;
 
-Defining Prototype Services
----------------------------
+Defining Factory Services
+-------------------------
 
 By default, each time you get a service, Pimple returns the **same instance**
 of it. If you want a different instance to be returned for all calls, wrap your
-anonymous function with the ``prototype()`` method::
+anonymous function with the ``factory()`` method::
 
-    $container['session'] = $container->prototype(function ($c) {
+    $container['session'] = $container->factory(function ($c) {
         return new Session($c['session_storage']);
     });
 

--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -33,7 +33,7 @@
 class Pimple implements ArrayAccess
 {
     protected $values = array();
-    protected $protected;
+    protected $factories;
 
     /**
      * Instantiate the container.
@@ -45,7 +45,7 @@ class Pimple implements ArrayAccess
     public function __construct(array $values = array())
     {
         $this->values = $values;
-        $this->protected = new \SplObjectStorage();
+        $this->factories = new \SplObjectStorage();
     }
 
     /**
@@ -62,7 +62,7 @@ class Pimple implements ArrayAccess
      */
     public function offsetSet($id, $value)
     {
-        if (!is_object($value) || !method_exists($value, '__invoke') || isset($this->protected[$value])) {
+        if (!is_object($value) || !method_exists($value, '__invoke') || isset($this->factories[$value])) {
             $this->values[$id] = $value;
         } else {
             $this->values[$id] = function ($c) use ($value) {
@@ -128,19 +128,19 @@ class Pimple implements ArrayAccess
     }
 
     /**
-     * Protects a callable from being a shared service.
+     * Marks a callable as being a factory service.
      *
-     * @param object $callable A service definition to wrap to use as a prototype
+     * @param object $callable A service definition to be used as a factory
      *
-     * @return Closure The prototype closure
+     * @return Closure The factory closure
      */
-    public function prototype($callable)
+    public function factory($callable)
     {
         if (!is_object($callable) || !method_exists($callable, '__invoke')) {
             throw new InvalidArgumentException('Service definition is not a Closure or invokable object.');
         }
 
-        $this->protected->attach($callable);
+        $this->factories->attach($callable);
 
         return $callable;
     }
@@ -164,7 +164,7 @@ class Pimple implements ArrayAccess
             return $callable;
         };
 
-        $this->protected->attach($callable);
+        $this->factories->attach($callable);
 
         return $callable;
     }

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -57,7 +57,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testServicesShouldBeDifferent()
     {
         $pimple = new Pimple();
-        $pimple['service'] = $pimple->prototype(function () {
+        $pimple['service'] = $pimple->factory(function () {
             return new Service();
         });
 
@@ -176,7 +176,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testRaw()
     {
         $pimple = new Pimple();
-        $pimple['service'] = $definition = $pimple->prototype(function () { return 'foo'; });
+        $pimple['service'] = $definition = $pimple->factory(function () { return 'foo'; });
         $this->assertSame($definition, $pimple->raw('service'));
     }
 
@@ -261,10 +261,10 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Service definition is not a Closure or invokable object.
      */
-    public function testPrototypeFailsForInvalidServiceDefinitions($service)
+    public function testFactoryFailsForInvalidServiceDefinitions($service)
     {
         $pimple = new Pimple();
-        $pimple->prototype($service);
+        $pimple->factory($service);
     }
 
     /**


### PR DESCRIPTION
The only valid usage for the `prototype` type of services is factories. So, I'd like to rename prototype to factory in the code to make things easier to understand.
