### PR TITLE
Remove reassignment on extend

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -216,7 +216,7 @@ class Pimple implements ArrayAccess
 
         $factory = $this->values[$id];
 
-        return $this->values[$id] = function ($c) use ($callable, $factory) {
+        return function ($c) use ($callable, $factory) {
             return $callable($factory($c), $c);
         };
     }

--- a/tests/Pimple/Tests/PimpleTest.php
+++ b/tests/Pimple/Tests/PimpleTest.php
@@ -207,7 +207,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
             return new Service();
         };
 
-        $pimple->extend('shared_service', $service);
+        $pimple['shared_service'] = $pimple->prototype($pimple->extend('shared_service', $service));
 
         $serviceOne = $pimple['shared_service'];
         $this->assertInstanceOf('Pimple\Tests\Service', $serviceOne);


### PR DESCRIPTION
I think I originally put the reassignment in there as I failed to recognise that the most common use case would require re-sharing the extended service, and thought people would just be able to do:

```
$app->extend('twig', function ($twig) {
```

I think we should take the opportunity of 2.0 to remove the reassignment.
