### PR TITLE
Added getValues() method to allow read-only access to the private values array

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -258,4 +258,14 @@ class Pimple implements ArrayAccess
     {
         return array_keys($this->values);
     }
+
+    /**
+     * Returns an array of all parameters and objects
+     *
+     * @return array An array of parameters or objects
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
 }


### PR DESCRIPTION
When extending the Pimple class to provide additional functionality I was previously accessing `$this->values` directly when it was protected. As I was only reading the data, adding a getter (as I've done in this PR) is perfectly fine but I think it's important to expose this array in order to allow extensions.

Note: I realize it would be possible to access the information by using the public `keys()` method and then iterating for each key and requesting it's value, however this would have a significant performance impact.
