### PR TITLE
Allow setting protected and factory services inside the constructor.

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -48,11 +48,12 @@ class Pimple implements ArrayAccess
      */
     public function __construct(array $values = array())
     {
+        $this->factories = new \SplObjectStorage();
+        $this->protected = new \SplObjectStorage();
+        
         foreach ($values as $key => $value) {
             $this->offsetSet($key, $value);
         }
-        $this->factories = new \SplObjectStorage();
-        $this->protected = new \SplObjectStorage();
     }
 
     /**


### PR DESCRIPTION
Fixes the following scenario. 

``` php

class Foo extends Pimple
{
    public function __construct()
    {
        parent::__construct([
            // $this->protect(), while callable, does not yet have
            // $this->protected initialized, so it blows up.
            'bar' => $this->protect(function () {
                 return 'Hi, Fabien!';
             }),
        ]);
    }
}

$foo = new Foo(); // kersplode!
```

This has no effect when constructing a bare Pimple object, since you cannot call `protect()` without first fully instantiating the object.

``` php
$pimple = new Pimple([
    // $pimple->protect() is obviously not callable here since
    // the object isn't fully constructed.
]);
```

I'm going to send another PR for fixing the documentation. The section about packaging a container for reusability is incorrect since it suggests that you do not need to call the parent constructor (you totally do in Pimple 2.0).
