### PR TITLE
Minor issue(103) quick fix and some code clarifications

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -247,6 +247,7 @@ class Pimple implements ArrayAccess
         };
 
         if (isset($this->factories[$factory])) {
+            $this->factories->detach($factory);
             $this->factories->attach($extended);
         }
 


### PR DESCRIPTION
Fix issue #103 `Pimple::factories` may keep dead objects after `extend()` and `offsetUnset()`

Other than that, 2 minor changes
- in `Pimple::raw()` changed `array_key_exists($id,$this->values)` to `isset($this->keys[$id])`. Isset will work much better/faster and, besides, any value set **must have** an identifying key in `keys`
- some minor code disentaglements `return $this[$id] = $someValue;` makes an implicit call to `offsetSet()`, so I made it explicit
