### PR TITLE
use of keys prop for isset() check of services/values

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -122,7 +122,7 @@ class Pimple implements ArrayAccess
      */
     public function offsetExists($id)
     {
-        return array_key_exists($id, $this->values);
+        return isset($this->keys[$id]);
     }
 
     /**


### PR DESCRIPTION
Why not just use the keys prop for check if a service/value exists in Pimple?
