### PR TITLE
improve performance for v1.1

### DIFF
--- a/lib/Pimple.php
+++ b/lib/Pimple.php
@@ -45,7 +45,7 @@ class Pimple implements ArrayAccess
     public function __construct(array $values = array())
     {
         foreach ($values as $key => $value) {
-		    $this->offsetSet($key, $value);
+            $this->offsetSet($key, $value);
         }
     }
 
@@ -64,7 +64,7 @@ class Pimple implements ArrayAccess
     public function offsetSet($id, $value)
     {
         $this->values[$id] = $value;
-		$this->keys[$id] = true;
+        $this->keys[$id] = true;
     }
 
     /**


### PR DESCRIPTION
I added the performance improvement from v2.x in v1.1, with $keys instead of array_key_exists.
Why? Silex master branch still uses Pimple 1.1, and could be convenient while Silex 2 don't come out.
