### PR TITLE
Fix download link in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,5 +170,5 @@ anonymous function with the ``factory()`` method
         return new Session($c['session_storage']);
     });
 
-.. _Download it:              https://raw2.github.com/fabpot/Pimple/master/lib/Pimple.php
+.. _Download it:              https://github.com/fabpot/Pimple/raw/master/src/Pimple/Container.php
 .. _Pimple 1.x documentation: https://github.com/fabpot/Pimple/tree/1.1


### PR DESCRIPTION
Because current link lead to a 404:

```
curl -i https://raw2.github.com/fabpot/Pimple/master/lib/Pimple.php
HTTP/1.1 404 Not Found
Date: Tue, 29 Apr 2014 16:10:20 GMT
Server: Apache
Content-Security-Policy: default-src 'none'
Access-Control-Allow-Origin: https://render.githubusercontent.com
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000
Content-Length: 9
Accept-Ranges: bytes
Via: 1.1 varnish
X-Served-By: cache-lcy1128-LCY
X-Cache: MISS
X-Cache-Hits: 0
Expires: Tue, 29 Apr 2014 16:15:20 GMT
Source-Age: 0

Not Found
```

Note: The new link lead to a `302`, but thanks to the redirection, the link will always be good.
