### PR TITLE
Made the phpt tests report a failure exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
 
 env:
-  - PIMPLE_EXT=no
-  - PIMPLE_EXT=yes
+  matrix:
+    - PIMPLE_EXT=no
+    - PIMPLE_EXT=yes
+  global:
+    - REPORT_EXIT_STATUS=1
 
 php:
   - 5.3


### PR DESCRIPTION
Without the REPORT_EXIT_STATUS environment variable, running phpt tests on the extension will always report a success exit code, which does not make the build fail on failure
