### PR TITLE
added simple compiler pass

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -39,6 +39,7 @@ class Container implements \ArrayAccess
     private $frozen = array();
     private $raw = array();
     private $keys = array();
+    private $passes = array();
 
     /**
      * Instantiate the container.
@@ -274,5 +275,33 @@ class Container implements \ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * Registers a callable as compile pass
+     *
+     * @param callable $callable
+     *
+     * @throws \InvalidArgumentException if the callback is not a callable
+     */
+    public function pass($callable)
+    {
+        if (!is_callable($callable)) {
+            throw new \InvalidArgumentException('Pass is not a Closure or invokable object.');
+        }
+
+        $this->passes[] = $callable;
+    }
+
+    /**
+     * Compiles the Container by executing all passes
+     */
+    public function compile()
+    {
+        foreach ($this->passes as $callable) {
+            $callable($this);
+        }
+
+        $this->passes = array();
     }
 }

--- a/tests/PimpleTest.php
+++ b/tests/PimpleTest.php
@@ -431,4 +431,33 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         });
         $this->assertSame('bar.baz', $pimple['bar']);
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRegisteringInvalidPass()
+    {
+        $pimple = new Container();
+
+        $pimple->pass('foo');
+    }
+
+    public function testRegisterPassAndCompile()
+    {
+        $pimple = new Container();
+
+        $cb = function ($pimple) {
+            $pimple['foo'] = 'bar';
+        };
+
+        $pimple->pass($cb);
+
+        $this->assertFalse($pimple->offsetExists('foo'));
+
+        $pimple->compile();
+
+        $this->assertEquals('bar', $pimple['foo']);
+    }
+
+
 }


### PR DESCRIPTION
this PR adds the ability to register `compiler passes`

its useful to avoid circular references. in my case it was a `EventSubscriber` which needed a Service which needed the `EventDispatcher``

``` php

//normal service definitions
$pimple['eventDispatcher'] = function($pimple) {
    return new EventDispatcher();
}
$pimple['service'] = function($pimple) {
    return new Service($pimple['eventDispatcher']);
}
$pimple['subscriber'] = function($pimple) {
    return new Subscriber($pimple['service']);
}

// a direct binding would result in an error:
$pimple->extend('eventDispatcher', function($eventDispatcher, $pimple){
    $eventDispatcher->addSubscriber($pimple['subscriber']);
    return $eventDispatcher;
});

//lazy subscriber binding, this works:
$pimple->pass(function($pimple){
    $pimple['eventDispatcher']->addSubscriber($pimple['subscriber']);
});

//after every is defined, compile the container
$pimple->compile();
```
