### PR TITLE
Can not extend a value after access it for the first time

### DIFF
--- a/tests/PimpleTest.php
+++ b/tests/PimpleTest.php
@@ -206,7 +206,8 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $pimple['factory_service'] = $pimple->factory(function () {
             return new Fixtures\Service();
         });
-
+        
+        $this->assertInstanceOf('Pimple\Tests\Fixtures\Service', $pimple['shared_service']);
         $pimple->extend('shared_service', $service);
         $serviceOne = $pimple['shared_service'];
         $this->assertInstanceOf('Pimple\Tests\Fixtures\Service', $serviceOne);


### PR DESCRIPTION
I don't know, if this is the correct behavior or not, but this throw an exception (In pimple 1x it was ok) : 

``` php
$container['mail'] = function ($c) {
    return new \Zend_Mail();
};
$test = $container['mail'];

$container->extend('mail', function($mail, $c) {
    $mail->setFrom($c['mail.default_from']);

    return $mail;
});
```

The test provided by this PR is a fail test. just for demonstrate the problem. 
