### PR TITLE
Added shortcut method to define instances

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -246,6 +246,18 @@ class Container implements \ArrayAccess
 
         return $this[$id] = $extended;
     }
+    
+    /**
+     * A shortcut method to define instances in the container.
+     * 
+     * @param object $object The instance
+     */
+    public function instance($object)
+    {
+        return function () use ($object) {
+            return $object;
+        }
+    }
 
     /**
      * Returns all defined value names.


### PR DESCRIPTION
This allows you to do:

``` php
$container['foo'] = $container->instance($this);
```

Which is a lot easier to type than:

``` php
$that = $this;
$container['foo'] = function ($c) use ($that) {
    return $that;
};
```
