### PR TITLE
fixed code when dealing with circular references

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -108,10 +108,13 @@ class Container implements \ArrayAccess
             return $this->values[$id]($this);
         }
 
-        $this->frozen[$id] = true;
-        $this->raw[$id] = $this->values[$id];
+        $raw = $this->values[$id];
+        $val = $this->values[$id] = $raw($this);
+        $this->raw[$id] = $raw;
 
-        return $this->values[$id] = $this->values[$id]($this);
+        $this->frozen[$id] = true;
+
+        return $val;
     }
 
     /**


### PR DESCRIPTION
Fix for #120 (thanks @davedevelopment). At least, it's behaving "correctly" when there is a circular reference. Not sure if this is worth fixing, but that would make the PHP and C implementations behave in the same way as the C version already segfaults in such a case.
