### PR TITLE
README.rst : Correct a missing closing parenthesis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ run on your service just after it is created:
         $storage->...();
 
         return $storage;
-    };
+    });
 
 The first argument is the name of the service to extend, the second a function
 that gets access to the object instance and the container.


### PR DESCRIPTION
I just noticed that an example on the README was missing a closing parentheses. Thanks.
