### PR TITLE
Fully qualify class name for expectedException in PimpleTest

### DIFF
--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -375,7 +375,7 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Cannot override frozen service "foo".
      */
     public function testOverridingServiceAfterFreeze()


### PR DESCRIPTION
As far as I can tell PHPUnit currently doesn't seem to mind if
you don't import or specify the full namespace for an
expectedException if it's in the root namespace. This is expected
as the class name is a string.

This seems the right thing to do though, and is done in other
places in the test.