### PR TITLE
Fix PHP extension installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ Alternatively, Pimple is also available as a PHP C extension:
 
 .. code-block:: bash
 
-    $ cd ext/pimple
+    $ git clone https://github.com/silexphp/Pimple
+    $ cd Pimple/ext/pimple
     $ phpize
     $ ./configure
     $ make


### PR DESCRIPTION
I think it would be better if we explicitly add `git clone` and `cd` steps, as finding the extension sources might be not so obvious.