### PR TITLE
Awareness capabilities to instances created by Pimple

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -66,8 +66,9 @@ class Container implements \ArrayAccess
      * as function names (strings) are callable (creating a function with
      * the same name as an existing parameter would break your container).
      *
-     * @param  string            $id    The unique identifier for the parameter or object
-     * @param  mixed             $value The value of the parameter or a closure to define an object
+     * @param string $id    The unique identifier for the parameter or object
+     * @param mixed  $value The value of the parameter or a closure to define an object
+     *
      * @throws \RuntimeException Prevent override of a frozen service
      */
     public function offsetSet($id, $value)

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -110,6 +110,9 @@ class Container implements \ArrayAccess
 
         $raw = $this->values[$id];
         $val = $this->values[$id] = $raw($this);
+        if ($val instanceof PimpleAwarenessInterface || $val instanceof PimpleAwarenessTrait) {
+            $val->setDependencyInjectionContainer($this);
+        }
         $this->raw[$id] = $raw;
 
         $this->frozen[$id] = true;

--- a/src/Pimple/PimpleAwarenessInterface.php
+++ b/src/Pimple/PimpleAwarenessInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple;
+
+/**
+ * Pimple service provider interface.
+ *
+ * @author  Fabien Potencier
+ * @author  Dominik Zogg
+ * @author  Sebastian Machuca
+ */
+interface PimpleAwarenessInterface
+{
+    /**
+     * * Set the Dependency Injection Container. This will happen automatically when Pimple is instantiating a class
+     * checking if the class is an instance of this interface. This makes a lot more sense for PHP 5.3
+     * From PHP 5.4 onwards is much easier to use the trait.
+     * @param Container $pimple An Container instance
+     */
+    public function setDependencyInjectionContainer(Container $pimple);
+
+    /**
+     * @return Container
+     */
+    public function getDependencyInjectionContainer();
+}

--- a/src/Pimple/PimpleAwarenessInterface.php
+++ b/src/Pimple/PimpleAwarenessInterface.php
@@ -39,6 +39,7 @@ interface PimpleAwarenessInterface
      * * Set the Dependency Injection Container. This will happen automatically when Pimple is instantiating a class
      * checking if the class is an instance of this interface. This makes a lot more sense for PHP 5.3
      * From PHP 5.4 onwards is much easier to use the trait.
+     *
      * @param Container $pimple An Container instance
      */
     public function setDependencyInjectionContainer(Container $pimple);

--- a/src/Pimple/PimpleAwarenessTrait.php
+++ b/src/Pimple/PimpleAwarenessTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple;
+
+/**
+ * Pimple service provider interface.
+ *
+ * @author  Fabien Potencier
+ * @author  Dominik Zogg
+ * @author  Sebastian Machuca
+ */
+trait PimpleAwarenessTrait
+{
+    /**
+     * @var Container
+     */
+    private $pimple;
+
+    /**
+     * Set the Dependency Injection Container. This will happen automatically when Pimple is instantiating a class
+     * checking if the class is an instance of this trait.
+     * @param Container $pimple An Container instance
+     */
+    public function setDependencyInjectionContainer(Container $pimple)
+    {
+        $this->pimple = $pimple;
+    }
+
+    /**
+     * @return Container
+     */
+    public function getDependencyInjectionContainer()
+    {
+        return $this->pimple;
+    }
+}

--- a/src/Pimple/PimpleAwarenessTrait.php
+++ b/src/Pimple/PimpleAwarenessTrait.php
@@ -43,6 +43,7 @@ trait PimpleAwarenessTrait
     /**
      * Set the Dependency Injection Container. This will happen automatically when Pimple is instantiating a class
      * checking if the class is an instance of this trait.
+     *
      * @param Container $pimple An Container instance
      */
     public function setDependencyInjectionContainer(Container $pimple)


### PR DESCRIPTION
If a class either implements the interface or uses the trait
will automatically be able to call the depency injection container
in its internal scope.

This can be very usefull when sometimes, you need access services from
an instance in the container, but is not convenient send the instance
of the service in the constructor (IoC).