### PR TITLE
Fix segfault in extension's protect

### DIFF
--- a/ext/pimple/pimple.c
+++ b/ext/pimple/pimple.c
@@ -513,6 +513,7 @@ PHP_METHOD(Pimple, protect)
 	pobj = (pimple_object *)zend_object_store_get_object(getThis() TSRMLS_CC);
 
 	if (zend_hash_index_update(&pobj->protected, bucket.handle_num, (void *)&bucket, sizeof(pimple_bucket_value), NULL) == SUCCESS) {
+		Z_ADDREF_P(protected);
 		RETURN_ZVAL(protected, 1 , 0);
 	} else {
 		pimple_free_bucket(&bucket);


### PR DESCRIPTION
Fixes a segfault in the extension. The function being protected seems to need to have the refcount incremented.

```
php --version
PHP 5.5.9-1ubuntu4.11 (cli) (built: Jul  2 2015 15:23:08) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans
```

tests/015.mem
```
==32129== Invalid read of size 1
==32129==    at 0x6DDE55: zval_call_destructor (zend_execute_API.c:203)
==32129==    by 0x6FBE63: zend_hash_reverse_apply (zend_hash.c:799)
==32129==    by 0x6DE290: shutdown_destructors (zend_execute_API.c:217)
==32129==    by 0x6EDD23: zend_call_destructors (zend.c:919)
==32129==    by 0x68E2A4: php_request_shutdown (main.c:1750)
==32129==    by 0x79EF49: do_cli (php_cli.c:1177)
==32129==    by 0x461E0F: main (php_cli.c:1378)
==32129==  Address 0x77d5b74 is 20 bytes inside a block of size 32 free'd
==32129==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==32129==    by 0x750C508: pimple_bucket_dtor (pimple.c:490)
==32129==    by 0x6FB977: zend_hash_destroy (zend_hash.c:560)
==32129==    by 0x750CEE1: pimple_free_object_storage (pimple.c:189)
==32129==    by 0x715E3B: zend_objects_store_del_ref_by_handle_ex (zend_objects_API.c:226)
==32129==    by 0x715E62: zend_objects_store_del_ref (zend_objects_API.c:178)
==32129==    by 0x6DDEBF: _zval_ptr_dtor (zend_variables.h:35)
==32129==    by 0x6FA334: zend_hash_apply_deleter (zend_hash.c:650)
==32129==    by 0x6FBE78: zend_hash_reverse_apply (zend_hash.c:804)
==32129==    by 0x6DE290: shutdown_destructors (zend_execute_API.c:217)
==32129==    by 0x6EDD23: zend_call_destructors (zend.c:919)
==32129==    by 0x68E2A4: php_request_shutdown (main.c:1750)
==32129== 
==32129== Invalid read of size 4
==32129==    at 0x6DDE62: zval_call_destructor (zend_execute_API.c:203)
==32129==    by 0x6FBE63: zend_hash_reverse_apply (zend_hash.c:799)
==32129==    by 0x6DE290: shutdown_destructors (zend_execute_API.c:217)
==32129==    by 0x6EDD23: zend_call_destructors (zend.c:919)
==32129==    by 0x68E2A4: php_request_shutdown (main.c:1750)
==32129==    by 0x79EF49: do_cli (php_cli.c:1177)
==32129==    by 0x461E0F: main (php_cli.c:1378)
==32129==  Address 0x77d5b70 is 16 bytes inside a block of size 32 free'd
==32129==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==32129==    by 0x750C508: pimple_bucket_dtor (pimple.c:490)
==32129==    by 0x6FB977: zend_hash_destroy (zend_hash.c:560)
==32129==    by 0x750CEE1: pimple_free_object_storage (pimple.c:189)
==32129==    by 0x715E3B: zend_objects_store_del_ref_by_handle_ex (zend_objects_API.c:226)
==32129==    by 0x715E62: zend_objects_store_del_ref (zend_objects_API.c:178)
==32129==    by 0x6DDEBF: _zval_ptr_dtor (zend_variables.h:35)
==32129==    by 0x6FA334: zend_hash_apply_deleter (zend_hash.c:650)
==32129==    by 0x6FBE78: zend_hash_reverse_apply (zend_hash.c:804)
==32129==    by 0x6DE290: shutdown_destructors (zend_execute_API.c:217)
==32129==    by 0x6EDD23: zend_call_destructors (zend.c:919)
==32129==    by 0x68E2A4: php_request_shutdown (main.c:1750)

```