### PR TITLE
add \Pimple\Container class to Pimple v1 for forward compatibility

### DIFF
--- a/lib/Pimple/Container.php
+++ b/lib/Pimple/Container.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple;
+
+/**
+ * Pimple Container class.
+ *
+ * This class exists for the compatibility between v1 and some later versions
+ *
+ * @author  Fabien Potencier
+ */
+class Container extends \Pimple
+{
+}


### PR DESCRIPTION
the document says: 

> Reading the Pimple 1.x code is also a good way to learn more about how to create a simple Dependency Injection Container (recent versions of Pimple are more focused on performance).

That's right. 
Pimple ver 1.x  is the best teacher to learn DI Container.

The only problem is , when we switch from v3 (or v2) to v1 and we should modify client codes which use Pimple.

This PR brings forward compatibility to v1.
It would help learners to read codes and do some work on v1 codes.

