### PR TITLE
Added the possibility to define alias to services

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -298,6 +298,7 @@ class Container implements \ArrayAccess
     /**
      * @param $alias
      * @param $service
+     *
      * @return $this
      */
     public function alias($alias, $service)

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -39,6 +39,7 @@ class Container implements \ArrayAccess
     private $frozen = array();
     private $raw = array();
     private $keys = array();
+    private $aliases = array();
 
     /**
      * Instantiate the container.
@@ -92,6 +93,20 @@ class Container implements \ArrayAccess
      */
     public function offsetGet($id)
     {
+        if (isset($this->aliases[$id])) {
+            try {
+                return $this->offsetGet($this->aliases[$id]);
+            } catch (\InvalidArgumentException $e) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Tryied to get the aliased service "%s" but its identifier "%s" was not defined.',
+                        $id,
+                        $this->aliases[$id]
+                    )
+                );
+            }
+        }
+
         if (!isset($this->keys[$id])) {
             throw new \InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
         }
@@ -276,6 +291,18 @@ class Container implements \ArrayAccess
         foreach ($values as $key => $value) {
             $this[$key] = $value;
         }
+
+        return $this;
+    }
+
+    /**
+     * @param $alias
+     * @param $service
+     * @return $this
+     */
+    public function alias($alias, $service)
+    {
+        $this->aliases[$alias] = $service;
 
         return $this;
     }

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -437,4 +437,30 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         });
         $this->assertSame('bar.baz', $pimple['bar']);
     }
+    
+    public function testDefiningAnAliasToService()
+    {
+        $pimple = new Container();
+        
+        $pimple['long.service.name'] = function () {
+            return 'foo';
+        };
+        
+        $pimple->alias('service', 'long.service.name');
+        
+        $this->assertSame('foo', $pimple['service']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Tryied to get the aliased service "foo" but its identifier "bar.long.service.name" was not defined.
+     */
+    public function testDefiningAnAliasToAnInvalidIdentifier()
+    {
+        $pimple = new Container();
+        
+        $pimple->alias('foo', 'bar.long.service.name');
+        
+        $pimple->offsetGet('foo');
+    }
 }

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -437,17 +437,17 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         });
         $this->assertSame('bar.baz', $pimple['bar']);
     }
-    
+
     public function testDefiningAnAliasToService()
     {
         $pimple = new Container();
-        
+
         $pimple['long.service.name'] = function () {
             return 'foo';
         };
-        
+
         $pimple->alias('service', 'long.service.name');
-        
+
         $this->assertSame('foo', $pimple['service']);
     }
 
@@ -458,9 +458,9 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function testDefiningAnAliasToAnInvalidIdentifier()
     {
         $pimple = new Container();
-        
+
         $pimple->alias('foo', 'bar.long.service.name');
-        
+
         $pimple->offsetGet('foo');
     }
 }


### PR DESCRIPTION
This PR adds the possibility to define an alias to services. A common and simple usage may be define services with long names and add a shortcut to them. 

```php
$pimple = new Container();
$pimple['some.long.service.name'] = function () { return 'foo' };
$pimple->alias('foo', 'some.long.service.name');
var_dump('foo' === $pimple['foo']); // true
```

Another usage of aliases is when we are working with interfaces and we need to register many of its implementations and use one of them as a main service.

```php
$pimple = new Container();

$pimple['feature.concrete.a'] = function () { return new ConcreteA() };
$pimple['feature.concrete.b'] = function () { return new ConcreteB() };
$pimple['feature.concrete.c'] = function () { return new ConcreteC() };

$pimple->alias('feature', 'feature.concrete.c');
```

We can easily move from 'feature.concrete.c' to 'feature.concrete.a' for example. I know that I can achieve such feature just writing a new service with short names, but we still need to write the full closure just to return the original service.

