### PR TITLE
Support "env()" parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,21 @@ You can now easily change the cookie name by overriding the
 ``session_storage_class`` parameter instead of redefining the service
 definition.
 
+Defining Parameters for Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you want your application to read parameters from environment
+variables. To do that, simply wrap your parameter into the `env()` keyword
+like so:
+
+.. code-block:: php
+
+    // define some parameters
+    $container['runtime_param'] = 'env(RUNTIME_PARAM)';
+
+Note that if the environment variable is not set, the parameter will be set
+to `null` and it will be cached for one request.
+
 Protecting Parameters
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,14 @@ like so:
 
 Note that if the environment variable is not set, the parameter will be set
 to `null` and it will be cached for one request.
+You can, however, define default values if you like:
+
+.. code-block:: php
+
+    // define some parameters
+    $container['runtime_param']      = 'env(RUNTIME_PARAM)';
+    $container['env(RUNTIME_PARAM)'] = 'default_value';
+
 
 Protecting Parameters
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -314,6 +314,10 @@ class Container implements \ArrayAccess
             return $this->envCache[$name] = $env;
         }
 
+        if ($this->offsetExists("env($name)")) {
+            return $this->envCache[$name] = $this->offsetGet("env($name)");
+        }
+
         return null;
     }
 }

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -39,6 +39,7 @@ class Container implements \ArrayAccess
     private $frozen = array();
     private $raw = array();
     private $keys = array();
+    private $envCache = array();
 
     /**
      * Instantiate the container.
@@ -102,6 +103,18 @@ class Container implements \ArrayAccess
             || isset($this->protected[$this->values[$id]])
             || !method_exists($this->values[$id], '__invoke')
         ) {
+
+            // Support for environment variables
+            if (is_scalar($this->values[$id])
+                && 0 === strpos($this->values[$id], 'env(')
+                && ')' === substr($this->values[$id], -1)
+                && 'env()' !== $this->values[$id]
+            ) {
+                $env = substr($this->values[$id], 4, -1);
+
+                return $this->getEnv($env);
+            }
+
             return $this->values[$id];
         }
 
@@ -278,5 +291,29 @@ class Container implements \ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * Fetches a variable from the environment.
+     *
+     * @param string $name The name of the environment variable
+     *
+     * @return scalar|null The value to use for the provided environment variable name or null if it does not exist
+     */
+    protected function getEnv($name)
+    {
+        if (isset($this->envCache[$name]) || array_key_exists($name, $this->envCache)) {
+            return $this->envCache[$name];
+        }
+
+        if (isset($_ENV[$name])) {
+            return $this->envCache[$name] = $_ENV[$name];
+        }
+
+        if (false !== $env = getenv($name)) {
+            return $this->envCache[$name] = $env;
+        }
+
+        return null;
     }
 }

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -51,6 +51,11 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         putenv('ENV_VALUE=foobar');
 
         $this->assertEquals('foobar', $pimple['param']);
+
+        // Test default value
+        $pimple['other_param']         = 'env(I_DO_NOT_EXIST)';
+        $pimple['env(I_DO_NOT_EXIST)'] = 'default_value';
+        $this->assertEquals('default_value', $pimple['other_param']);
     }
 
     public function testWithClosure()

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -46,14 +46,14 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $pimple = new Container();
         $pimple['param'] = 'env(ENV_VALUE)';
 
-        $this->assertEquals(null, $pimple['param']);
+        $this->assertNull($pimple['param']);
 
         putenv('ENV_VALUE=foobar');
 
         $this->assertEquals('foobar', $pimple['param']);
 
         // Test default value
-        $pimple['other_param']         = 'env(I_DO_NOT_EXIST)';
+        $pimple['other_param'] = 'env(I_DO_NOT_EXIST)';
         $pimple['env(I_DO_NOT_EXIST)'] = 'default_value';
         $this->assertEquals('default_value', $pimple['other_param']);
     }

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -41,6 +41,18 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value', $pimple['param']);
     }
 
+    public function testWithEnvString()
+    {
+        $pimple = new Container();
+        $pimple['param'] = 'env(ENV_VALUE)';
+
+        $this->assertEquals(null, $pimple['param']);
+
+        putenv('ENV_VALUE=foobar');
+
+        $this->assertEquals('foobar', $pimple['param']);
+    }
+
     public function testWithClosure()
     {
         $pimple = new Container();


### PR DESCRIPTION
Hi everbody,

I needed support for environment variables in Pimple and sure you can build your own `getenv()` stuff but I thought while I'm on it I might as well just port the implementation of the SF container to Pimple because it's not really a big deal and it might make the lives of devs easier. :)