### PR TITLE
moved the loading of options on provider register to allow options to…

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -29,7 +29,7 @@ namespace Pimple;
 /**
  * Container main class.
  *
- * @author  Fabien Potencier
+ * @author Fabien Potencier
  */
 class Container implements \ArrayAccess
 {
@@ -45,7 +45,7 @@ class Container implements \ArrayAccess
      *
      * Objects and parameters can be passed as argument to the constructor.
      *
-     * @param array $values The parameters or objects.
+     * @param array $values the parameters or objects.
      */
     public function __construct(array $values = array())
     {

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -271,11 +271,11 @@ class Container implements \ArrayAccess
      */
     public function register(ServiceProviderInterface $provider, array $values = array())
     {
-        $provider->register($this);
-
         foreach ($values as $key => $value) {
             $this[$key] = $value;
         }
+
+        $provider->register($this);
 
         return $this;
     }


### PR DESCRIPTION
… be used in register method


The options passed during the loading of options do not allow for a register method to use those options.  Adding the options before the register method is run allows the method to use those options.