### PR TITLE
Fix a typo as reported by fabbot.io

### DIFF
--- a/ext/pimple/pimple.c
+++ b/ext/pimple/pimple.c
@@ -419,7 +419,7 @@ static zval *pimple_object_read_dimension(zval *object, zval *offset, int type T
 	}
 
 	if (zend_hash_index_exists(&pimple_obj->factories, retval->handle_num)) {
-		/* Service is a factory, call it everytime and never cache its result */
+		/* Service is a factory, call it every time and never cache its result */
 		PIMPLE_CALL_CB
 		Z_DELREF_P(retval_ptr_ptr); /* fetch dim addr will increment refcount */
 		return retval_ptr_ptr;


### PR DESCRIPTION
Just applying a patch (as suggested by fabbot.io) to make it pass (because the red cross doesn't look nice):
![image](https://cloud.githubusercontent.com/assets/5679032/21414099/a81b9118-c850-11e6-8385-584105755a0c.png)

See http://fabbot.io/report/silexphp/Pimple/210/1ce4ec44d782ecacd45e8644006b8a5d96ca7b3d

