### PR TITLE
Use simple-phpunit to fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ php:
 
 before_script:
   - composer self-update
-  - COMPOSER_ROOT_VERSION=dev-master composer dump-autoload
+  - COMPOSER_ROOT_VERSION=dev-master composer install
   - if [ "$PIMPLE_EXT" == "yes" ]; then sh -c "cd ext/pimple && phpize && ./configure && make && sudo make install"; fi
   - if [ "$PIMPLE_EXT" == "yes" ]; then echo "extension=pimple.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
 
@@ -26,7 +26,7 @@ script:
   - cd ext/pimple
   - if [ "$PIMPLE_EXT" == "yes" ]; then yes n | make test | tee output ; grep -E 'Tests failed +. +0' output; fi
   - cd ../..
-  - phpunit
+  - ./vendor/bin/simple-phpunit
 
 matrix:
   exclude:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "symfony/phpunit-bridge": "^3.2"
+    },
     "autoload": {
         "psr-0": { "Pimple": "src/" }
     },


### PR DESCRIPTION
The build is currently breaking in [other pull requests](https://github.com/silexphp/Pimple/pull/216).  The reason is that the Travis PHPUnit binary is being used, and Travis have just upgraded this to PHPUnit 6 for PHP >=7.0.  Our tests here don't work in PHPUnit 6, and that is unlikely to change soon.

In [PRs in other projects](https://github.com/twigphp/Twig/pull/2339), objections have been raised about adding `phpunit/phpunit` to the `require-dev` sections of Composer files.  Therefore, this PR uses `symfony/phpunit-bridge` instead, to get PHPUnit < 6.