### PR TITLE
Add iterable PSR-11 service locator

### DIFF
--- a/src/Pimple/ServiceLocator.php
+++ b/src/Pimple/ServiceLocator.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple;
+
+use Pimple\Exception\UnknownIdentifierException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Iterable Pimple/PSR-11 service locator.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class ServiceLocator implements \Countable, \Iterator, ContainerInterface
+{
+    private $container;
+    private $aliases = array();
+
+    /**
+     * ServiceLocator constructor.
+     *
+     * @param Container $container The Container instance used to locate services
+     * @param array     $ids       Array of service ids that can be located. String keys can be used to define aliases
+     */
+    public function __construct(Container $container, array $ids)
+    {
+        $this->container = $container;
+
+        foreach ($ids as $key => $id) {
+            $this->aliases[is_int($key) ? $id : $key] = $id;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        if (!isset($this->aliases[$id])) {
+            throw new UnknownIdentifierException($id);
+        }
+
+        return $this->container[$this->aliases[$id]];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return isset($this->aliases[$id]);
+    }
+
+    public function count()
+    {
+        return count($this->aliases);
+    }
+
+    public function rewind()
+    {
+        reset($this->aliases);
+    }
+
+    public function current()
+    {
+        return $this->container[current($this->aliases)];
+    }
+
+    public function key()
+    {
+        return key($this->aliases);
+    }
+
+    public function next()
+    {
+        next($this->aliases);
+    }
+
+    public function valid()
+    {
+        return null !== key($this->aliases);
+    }
+}

--- a/src/Pimple/Tests/ServiceLocatorTest.php
+++ b/src/Pimple/Tests/ServiceLocatorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Pimple\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+use Pimple\ServiceLocator;
+
+/**
+ * ServiceLocator test case.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class ServiceLocatorTest extends TestCase
+{
+    public function testCanAccessServices()
+    {
+        $pimple = new Container();
+        $pimple['service'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('service'));
+
+        $this->assertSame($pimple['service'], $locator->get('service'));
+    }
+
+    public function testCanAccessAliasedServices()
+    {
+        $pimple = new Container();
+        $pimple['service'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('alias' => 'service'));
+
+        $this->assertSame($pimple['service'], $locator->get('alias'));
+    }
+
+    /**
+     * @expectedException \Pimple\Exception\UnknownIdentifierException
+     * @expectedExceptionMessage Identifier "service" is not defined.
+     */
+    public function testCannotAccessAliasedServicesUsingRealIdentifier()
+    {
+        $pimple = new Container();
+        $pimple['service'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('alias' => 'service'));
+
+        $service = $locator->get('service');
+    }
+
+    /**
+     * @expectedException \Pimple\Exception\UnknownIdentifierException
+     * @expectedExceptionMessage Identifier "service" is not defined.
+     */
+    public function testGetValidatesServiceCanBeLocated()
+    {
+        $pimple = new Container();
+        $pimple['service'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('foo'));
+
+        $service = $locator->get('service');
+    }
+
+    public function testHasValidatesServiceCanBeLocated()
+    {
+        $pimple = new Container();
+        $pimple['service1'] = function () {
+            return new Fixtures\Service();
+        };
+        $pimple['service2'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('service1'));
+
+        $this->assertTrue($locator->has('service1'));
+        $this->assertFalse($locator->has('service2'));
+    }
+
+    public function testHasDoesNotCheckIfServiceExists()
+    {
+        $pimple = new Container();
+        $pimple['service'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('foo' => 'service', 'bar' => 'invalid'));
+
+        $this->assertTrue($locator->has('foo'));
+        $this->assertTrue($locator->has('bar'));
+    }
+
+    public function testCount()
+    {
+        $pimple = new Container();
+
+        $locator = new ServiceLocator($pimple, array('service1', 'service2', 'service3'));
+
+        $this->assertSame(3, count($locator));
+    }
+
+    public function testIsIterable()
+    {
+        $pimple = new Container();
+        $pimple['service1'] = function () {
+            return new Fixtures\Service();
+        };
+        $pimple['service2'] = function () {
+            return new Fixtures\Service();
+        };
+
+        $locator = new ServiceLocator($pimple, array('service1', 'service2'));
+
+        $this->assertSame(array('service1' => $pimple['service1'], 'service2' => $pimple['service2']), iterator_to_array($locator));
+    }
+}


### PR DESCRIPTION
*Note: the tests fail as this branch depends on #222*

Adds a PSR-11 compliant `ServiceLocator` class. Services can be made locatable using aliases:

```php
$locator = new ServiceLocator(
    $pimple, 
    array('service1', 'service2', 'event_dispatcher' => 'dispatcher')
);
```

It can also be used whenever you need to pass a lazy collection of services. 

For instance, the Silex `SecurityServiceProvider` could be modified to benefit from symfony/symfony#21450 by changing:

```php
    $app['security.authentication_providers'] = array_map(function ($provider) use ($app) {
        return $app[$provider];
    }, array_unique($providers));
	// ...
    $app['security.authentication_manager'] = function ($app) {
        $manager = new AuthenticationProviderManager($app['security.authentication_providers']);
        $manager->setEventDispatcher($app['dispatcher']);

        return $manager;
    };
```

and doing this instead:

```php
    $app['security.authentication_providers'] = array_unique($providers);
	// ...
    $app['security.authentication_manager'] = function ($app) {
        $manager = new AuthenticationProviderManager(new ServiceLocator($app, $app['security.authentication_providers']));
        $manager->setEventDispatcher($app['dispatcher']);

        return $manager;
    };
```

### Potential enhancements

The second constructor parameter could be made optional to let users access all the services of the Pimple instance. I personally think another class would be better suited for this, but I am ready to make the change.

The `ServiceLocator` class could extend `Pimple\Container`. This would allow it to be used as a read-only `Container` replacement. I didn't need this (my use case is about the _iterable_ behavior), but am ready to make the change too is somebody wants it.
