### PR TITLE
Fix the HHVM travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 before_script:
   - composer self-update
@@ -29,9 +28,11 @@ script:
   - ./vendor/bin/simple-phpunit
 
 matrix:
-  exclude:
+  include:
     - php: hhvm
-      env: PIMPLE_EXT=yes
+      dist: trusty
+      env: PIMPLE_EXT=no
+  exclude:
     - php: 7.0
       env: PIMPLE_EXT=yes
     - php: 7.1


### PR DESCRIPTION
Fixed the HHVM build by explicitely adding HHVM + trusty + _PIMPLE_EXT=no_ to the matrix.