### PR TITLE
Added ServiceIterator

### DIFF
--- a/src/Pimple/ServiceIterator.php
+++ b/src/Pimple/ServiceIterator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple;
+
+/**
+ * Lazy service iterator.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+final class ServiceIterator implements \Iterator
+{
+    private $container;
+    private $ids;
+
+    public function __construct(Container $container, array $ids)
+    {
+        $this->container = $container;
+        $this->ids = $ids;
+    }
+
+    public function rewind()
+    {
+        reset($this->ids);
+    }
+
+    public function current()
+    {
+        return $this->container[current($this->ids)];
+    }
+
+    public function key()
+    {
+        return current($this->ids);
+    }
+
+    public function next()
+    {
+        next($this->ids);
+    }
+
+    public function valid()
+    {
+        return null !== key($this->ids);
+    }
+}

--- a/src/Pimple/Tests/ServiceIteratorTest.php
+++ b/src/Pimple/Tests/ServiceIteratorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Pimple.
+ *
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Pimple\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+use Pimple\ServiceIterator;
+use Pimple\Tests\Fixtures\Service;
+
+class ServiceIteratorTest extends TestCase
+{
+    public function testIsIterable()
+    {
+        $pimple = new Container();
+        $pimple['service1'] = function () {
+            return new Service();
+        };
+        $pimple['service2'] = function () {
+            return new Service();
+        };
+        $pimple['service3'] = function () {
+            return new Service();
+        };
+        $iterator = new ServiceIterator($pimple, array('service1', 'service2'));
+
+        $this->assertSame(array('service1' => $pimple['service1'], 'service2' => $pimple['service2']), iterator_to_array($iterator));
+    }
+}


### PR DESCRIPTION
Adds a `ServiceIterator` that only initializes the services when iterated:

```php
$iterator = new ServiceIterator($pimple, array('service1', 'service2'));
foreach ($iterator as $service) {
}
```

It's useful:
- When you may not need to load all the services in the collection
- To avoid circular dependencies issues (see silexphp/Silex#1530)

The implementations (C and PHP) are ready to review, I'll add the documentation and ping you once it's ready to merge.