### PR TITLE
Throw InvalidServiceIdentifierException when extending a protected closure

### DIFF
--- a/ext/pimple/pimple.c
+++ b/ext/pimple/pimple.c
@@ -714,7 +714,8 @@ PHP_METHOD(Pimple, extend)
 				pimple_throw_exception_string(pimple_ce_UnknownIdentifierException, Z_STRVAL_P(offset), Z_STRLEN_P(offset) TSRMLS_CC);
 				RETURN_NULL();
 			}
-			if (value->type != PIMPLE_IS_SERVICE) {
+
+			if (value->type != PIMPLE_IS_SERVICE || zend_hash_index_exists(&pobj->protected, value->handle_num)) {
 				pimple_throw_exception_string(pimple_ce_InvalidServiceIdentifierException, Z_STRVAL_P(offset), Z_STRLEN_P(offset) TSRMLS_CC);
 				RETURN_NULL();
 			}
@@ -732,7 +733,7 @@ PHP_METHOD(Pimple, extend)
 				pimple_throw_exception_string(pimple_ce_UnknownIdentifierException, Z_STRVAL_P(offset), Z_STRLEN_P(offset) TSRMLS_CC);
 				RETURN_NULL();
 			}
-			if (value->type != PIMPLE_IS_SERVICE) {
+			if (value->type != PIMPLE_IS_SERVICE || zend_hash_index_exists(&pobj->protected, value->handle_num)) {
 				convert_to_string(offset);
 				pimple_throw_exception_string(pimple_ce_InvalidServiceIdentifierException, Z_STRVAL_P(offset), Z_STRLEN_P(offset) TSRMLS_CC);
 				RETURN_NULL();

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -238,7 +238,7 @@ class Container implements \ArrayAccess
             throw new FrozenServiceException($id);
         }
 
-        if (!is_object($this->values[$id]) || !method_exists($this->values[$id], '__invoke')) {
+        if (!is_object($this->values[$id]) || !method_exists($this->values[$id], '__invoke') || isset($this->protected[$this->values[$id]])) {
             throw new InvalidServiceIdentifierException($id);
         }
 

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -392,6 +392,20 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Pimple\Exception\InvalidServiceIdentifierException
+     * @expectedExceptionMessage Identifier "foo" does not contain an object definition.
+     */
+    public function testExtendFailsIfEntryIsProtected()
+    {
+        $pimple = new Container();
+        $pimple['foo'] = $pimple->protect(function () {
+            return 'bar';
+        });
+
+        $pimple->extend('foo', function () {});
+    }
+
+    /**
      * @dataProvider badServiceDefinitionProvider
      * @expectedException \Pimple\Exception\ExpectedInvokableException
      * @expectedExceptionMessage Extension service definition is not a Closure or invokable object.


### PR DESCRIPTION
Fixes #190 by adding a test that checks if the entry you are trying to `extend` is a protected closure.