### PR TITLE
Fixed ServiceLocator compatibility with PHP5

### DIFF
--- a/src/Pimple/Psr11/ServiceLocator.php
+++ b/src/Pimple/Psr11/ServiceLocator.php
@@ -26,7 +26,7 @@
 
 namespace Pimple\Psr11;
 
-use Pimple\Container;
+use Pimple\Container as PimpleContainer;
 use Pimple\Exception\UnknownIdentifierException;
 use Psr\Container\ContainerInterface;
 
@@ -41,10 +41,10 @@ class ServiceLocator implements ContainerInterface
     private $aliases = array();
 
     /**
-     * @param Container $container The Container instance used to locate services
-     * @param array     $ids       Array of service ids that can be located. String keys can be used to define aliases
+     * @param PimpleContainer $container The Container instance used to locate services
+     * @param array           $ids       Array of service ids that can be located. String keys can be used to define aliases
      */
-    public function __construct(Container $container, array $ids)
+    public function __construct(PimpleContainer $container, array $ids)
     {
         $this->container = $container;
 


### PR DESCRIPTION
Merging #233 and #236 together broke the `ServiceLocator` compatibility with PHP 5.x (PHP complains because there is already a class named `Container` in the current namespace):

```
PHP Fatal error:  Cannot use Pimple\Container as Container because the name is already in use in /home/travis/build/skalpa/Pimple/src/Pimple/Psr11/ServiceLocator.php on line 29
```