### PR TITLE
Probably parameter names were mixed in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ If you change the ``session_storage`` service definition like below:
     };
 
 You can now easily change the cookie name by overriding the
-``session_storage_class`` parameter instead of redefining the service
+``cookie_name`` parameter instead of redefining the service
 definition.
 
 Protecting Parameters


### PR DESCRIPTION
I believe that `session_storage_class` and `session_storage` parameters were mixed. Overriding `cookie_name` parameter will easily change cookie name, not editing `session_storage_class`.