### PR TITLE
exclude tests and ext from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/ext export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /ext export-ignore
+
+# tests
+/phpunit.xml.dist export-ignore
+/src/Pimple/Tests/ export-ignore


### PR DESCRIPTION
second try for https://github.com/silexphp/Pimple/pull/57
perhaps opinions have changed in 5 years.

and if people need to install composer packages with full content, then can (and should) use `--prefer-source`.
