### PR TITLE
Feature request: Add PSR-11 compatibility in Pimple container

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -30,13 +30,14 @@ use Pimple\Exception\ExpectedInvokableException;
 use Pimple\Exception\FrozenServiceException;
 use Pimple\Exception\InvalidServiceIdentifierException;
 use Pimple\Exception\UnknownIdentifierException;
+use Psr\Container\ContainerInterface;
 
 /**
  * Container main class.
  *
  * @author Fabien Potencier
  */
-class Container implements \ArrayAccess
+class Container implements \ArrayAccess, ContainerInterface
 {
     private $values = array();
     private $factories;
@@ -294,5 +295,21 @@ class Container implements \ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * @see self::offsetGet()
+     */
+    public function get($id)
+    {
+        return $this->offsetGet($id);
+    }
+
+    /**
+     * @see self::offsetExists()
+     */
+    public function has($id)
+    {
+        return $this->offsetExists($id);
     }
 }


### PR DESCRIPTION
Please add PSR-11 functionality in the spirit of the PR.

The motivation is this:

If you want to write interoperable factories, you want to receive a PSR container. However, the factories will receive a Pimple container in any case. This is the reason why I have always used [xtreamwayz' implementation](https://github.com/xtreamwayz/pimple-container-interop).

He states that his project is superseded by [zend-pimple-config](https://github.com/zendframework/zend-pimple-config). They solved it by wrapping each factory in a closure. I fear that this is a performance penalty and I think there is no argument against implementing the PSR interface.