### PR TITLE
Enable static_lambda fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'all'],
+        'static_lambda' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(PhpCsFixer\Finder::create()->in(__DIR__.'/src'))

--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -255,7 +255,7 @@ class Container implements \ArrayAccess
 
         $factory = $this->values[$id];
 
-        $extended = function ($c) use ($callable, $factory) {
+        $extended = static function ($c) use ($callable, $factory) {
             return $callable($factory($c), $c);
         };
 

--- a/src/Pimple/Tests/Fixtures/PimpleServiceProvider.php
+++ b/src/Pimple/Tests/Fixtures/PimpleServiceProvider.php
@@ -43,11 +43,11 @@ class PimpleServiceProvider implements ServiceProviderInterface
     {
         $pimple['param'] = 'value';
 
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Service();
         };
 
-        $pimple['factory'] = $pimple->factory(function () {
+        $pimple['factory'] = $pimple->factory(static function () {
             return new Service();
         });
     }

--- a/src/Pimple/Tests/PimpleTest.php
+++ b/src/Pimple/Tests/PimpleTest.php
@@ -45,7 +45,7 @@ class PimpleTest extends TestCase
     public function testWithClosure()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
 
@@ -55,7 +55,7 @@ class PimpleTest extends TestCase
     public function testServicesShouldBeDifferent()
     {
         $pimple = new Container();
-        $pimple['service'] = $pimple->factory(function () {
+        $pimple['service'] = $pimple->factory(static function () {
             return new Fixtures\Service();
         });
 
@@ -71,10 +71,10 @@ class PimpleTest extends TestCase
     public function testShouldPassContainerAsParameter()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
-        $pimple['container'] = function ($container) {
+        $pimple['container'] = static function ($container) {
             return $container;
         };
 
@@ -86,7 +86,7 @@ class PimpleTest extends TestCase
     {
         $pimple = new Container();
         $pimple['param'] = 'value';
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
 
@@ -138,7 +138,7 @@ class PimpleTest extends TestCase
     {
         $pimple = new Container();
         $pimple['param'] = 'value';
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
 
@@ -185,7 +185,7 @@ class PimpleTest extends TestCase
     public function testRaw()
     {
         $pimple = new Container();
-        $pimple['service'] = $definition = $pimple->factory(function () {
+        $pimple['service'] = $definition = $pimple->factory(static function () {
             return 'foo';
         });
         $this->assertSame($definition, $pimple->raw('service'));
@@ -231,10 +231,10 @@ class PimpleTest extends TestCase
     public function testExtend($service)
     {
         $pimple = new Container();
-        $pimple['shared_service'] = function () {
+        $pimple['shared_service'] = static function () {
             return new Fixtures\Service();
         };
-        $pimple['factory_service'] = $pimple->factory(function () {
+        $pimple['factory_service'] = $pimple->factory(static function () {
             return new Fixtures\Service();
         });
 
@@ -262,10 +262,10 @@ class PimpleTest extends TestCase
         }
         $pimple = new Container();
 
-        $pimple['foo'] = $pimple->factory(function () {
+        $pimple['foo'] = $pimple->factory(static function () {
             return;
         });
-        $pimple['foo'] = $pimple->extend('foo', function ($foo, $pimple) {
+        $pimple['foo'] = $pimple->extend('foo', static function ($foo, $pimple) {
             return;
         });
         unset($pimple['foo']);
@@ -285,7 +285,7 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Identifier "foo" is not defined.');
 
         $pimple = new Container();
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -298,7 +298,7 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Identifier "foo" is not defined.');
 
         $pimple = new Container();
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -389,7 +389,7 @@ class PimpleTest extends TestCase
 
         $pimple = new Container();
         $pimple['foo'] = $service;
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -404,7 +404,7 @@ class PimpleTest extends TestCase
 
         $pimple = new Container();
         $pimple['foo'] = $service;
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -415,11 +415,11 @@ class PimpleTest extends TestCase
     public function testExtendingProtectedClosureDeprecation()
     {
         $pimple = new Container();
-        $pimple['foo'] = $pimple->protect(function () {
+        $pimple['foo'] = $pimple->protect(static function () {
             return 'bar';
         });
 
-        $pimple->extend('foo', function ($value) {
+        $pimple->extend('foo', static function ($value) {
             return $value.'-baz';
         });
 
@@ -435,7 +435,7 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Extension service definition is not a Closure or invokable object.');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
         };
         $pimple->extend('foo', $service);
     }
@@ -450,7 +450,7 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Extension service definition is not a Closure or invokable object.');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
         };
         $pimple->extend('foo', $service);
     }
@@ -461,12 +461,12 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Cannot override frozen service "foo".');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return new Fixtures\NonInvokable();
         };
         $foo = $pimple['foo'];
 
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -476,12 +476,12 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Cannot override frozen service "foo".');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return new Fixtures\Invokable();
         };
         $foo = $pimple['foo'];
 
-        $pimple->extend('foo', function () {
+        $pimple->extend('foo', static function () {
         });
     }
 
@@ -502,7 +502,7 @@ class PimpleTest extends TestCase
     public function serviceDefinitionProvider()
     {
         return [
-            [function ($value) {
+            [static function ($value) {
                 $service = new Fixtures\Service();
                 $service->value = $value;
 
@@ -515,12 +515,12 @@ class PimpleTest extends TestCase
     public function testDefiningNewServiceAfterFreeze()
     {
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
         $foo = $pimple['foo'];
 
-        $pimple['bar'] = function () {
+        $pimple['bar'] = static function () {
             return 'bar';
         };
         $this->assertSame('bar', $pimple['bar']);
@@ -532,12 +532,12 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Cannot override frozen service "foo".');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
         $foo = $pimple['foo'];
 
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'bar';
         };
     }
@@ -551,12 +551,12 @@ class PimpleTest extends TestCase
         $this->expectExceptionMessage('Cannot override frozen service "foo".');
 
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
         $foo = $pimple['foo'];
 
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'bar';
         };
     }
@@ -564,13 +564,13 @@ class PimpleTest extends TestCase
     public function testRemovingServiceAfterFreeze()
     {
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
         $foo = $pimple['foo'];
 
         unset($pimple['foo']);
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'bar';
         };
         $this->assertSame('bar', $pimple['foo']);
@@ -579,13 +579,13 @@ class PimpleTest extends TestCase
     public function testExtendingService()
     {
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
-        $pimple['foo'] = $pimple->extend('foo', function ($foo, $app) {
+        $pimple['foo'] = $pimple->extend('foo', static function ($foo, $app) {
             return "$foo.bar";
         });
-        $pimple['foo'] = $pimple->extend('foo', function ($foo, $app) {
+        $pimple['foo'] = $pimple->extend('foo', static function ($foo, $app) {
             return "$foo.baz";
         });
         $this->assertSame('foo.bar.baz', $pimple['foo']);
@@ -594,15 +594,15 @@ class PimpleTest extends TestCase
     public function testExtendingServiceAfterOtherServiceFreeze()
     {
         $pimple = new Container();
-        $pimple['foo'] = function () {
+        $pimple['foo'] = static function () {
             return 'foo';
         };
-        $pimple['bar'] = function () {
+        $pimple['bar'] = static function () {
             return 'bar';
         };
         $foo = $pimple['foo'];
 
-        $pimple['bar'] = $pimple->extend('bar', function ($bar, $app) {
+        $pimple['bar'] = $pimple->extend('bar', static function ($bar, $app) {
             return "$bar.baz";
         });
         $this->assertSame('bar.baz', $pimple['bar']);

--- a/src/Pimple/Tests/Psr11/ContainerTest.php
+++ b/src/Pimple/Tests/Psr11/ContainerTest.php
@@ -36,7 +36,7 @@ class ContainerTest extends TestCase
     public function testGetReturnsExistingService()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Service();
         };
         $psr = new PsrContainer($pimple);
@@ -58,7 +58,7 @@ class ContainerTest extends TestCase
     public function testHasReturnsTrueIfServiceExists()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Service();
         };
         $psr = new PsrContainer($pimple);

--- a/src/Pimple/Tests/Psr11/ServiceLocatorTest.php
+++ b/src/Pimple/Tests/Psr11/ServiceLocatorTest.php
@@ -41,7 +41,7 @@ class ServiceLocatorTest extends TestCase
     public function testCanAccessServices()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['service']);
@@ -52,7 +52,7 @@ class ServiceLocatorTest extends TestCase
     public function testCanAccessAliasedServices()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['alias' => 'service']);
@@ -66,7 +66,7 @@ class ServiceLocatorTest extends TestCase
         $this->expectExceptionMessage('Identifier "service" is not defined.');
 
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['alias' => 'service']);
@@ -80,7 +80,7 @@ class ServiceLocatorTest extends TestCase
         $this->expectExceptionMessage('Identifier "foo" is not defined.');
 
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['alias' => 'service']);
@@ -94,7 +94,7 @@ class ServiceLocatorTest extends TestCase
         $this->expectExceptionMessage('Identifier "invalid" is not defined.');
 
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['alias' => 'invalid']);
@@ -105,10 +105,10 @@ class ServiceLocatorTest extends TestCase
     public function testHasValidatesServiceCanBeLocated()
     {
         $pimple = new Container();
-        $pimple['service1'] = function () {
+        $pimple['service1'] = static function () {
             return new Fixtures\Service();
         };
-        $pimple['service2'] = function () {
+        $pimple['service2'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['service1']);
@@ -120,7 +120,7 @@ class ServiceLocatorTest extends TestCase
     public function testHasChecksIfTargetServiceExists()
     {
         $pimple = new Container();
-        $pimple['service'] = function () {
+        $pimple['service'] = static function () {
             return new Fixtures\Service();
         };
         $locator = new ServiceLocator($pimple, ['foo' => 'service', 'bar' => 'invalid']);

--- a/src/Pimple/Tests/ServiceIteratorTest.php
+++ b/src/Pimple/Tests/ServiceIteratorTest.php
@@ -36,13 +36,13 @@ class ServiceIteratorTest extends TestCase
     public function testIsIterable()
     {
         $pimple = new Container();
-        $pimple['service1'] = function () {
+        $pimple['service1'] = static function () {
             return new Service();
         };
-        $pimple['service2'] = function () {
+        $pimple['service2'] = static function () {
             return new Service();
         };
-        $pimple['service3'] = function () {
+        $pimple['service3'] = static function () {
             return new Service();
         };
         $iterator = new ServiceIterator($pimple, ['service1', 'service2']);


### PR DESCRIPTION
Enable [static_lambda], that requires php 5.4 which is now available.

[static_lambda]: https://mlocati.github.io/php-cs-fixer-configurator/#version:2.16|fixer:static_lambda