### PR TITLE
chubbyphp reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@ Pimple
     Pimple is now closed for changes. No new features will be added and no
     cosmetic changes will be accepted either.
 
+    If you like the simplicity of Pimple, but are looking for a solution that
+    is actively maintained and faster according to neutral `benchmarks`_,
+    implements PSR11 without an adapter, you can take a look at
+    the `chubbyphp/chubbyphp-container`_.
+
 .. caution::
 
     This is the documentation for Pimple 3.x. If you are using Pimple 1.x, read
@@ -329,3 +334,6 @@ when iterated over:
     }
 
 .. _Pimple 1.x documentation: https://github.com/silexphp/Pimple/tree/1.1
+
+.. _benchmarks: https://rawgit.com/kocsismate/php-di-container-benchmarks/master/var/benchmark.html
+.. _chubbyphp/chubbyphp-container: https://github.com/chubbyphp/chubbyphp-container/blob/master/doc/MigrateFromPimple.md


### PR DESCRIPTION
Hello @fabpot 

As far as i understand "Pimple is now closed for changes. No new features will be added and no cosmetic changes will be accepted either." only bug fixes will be done.

As long time user of Pimple i have build a dependency injection container myself, which the goal to make it faster, if possible even smaller (and it is) and have a container implementing PSR11 out of the box.

Besides the ->raw method everything done in Pimple can be achieved by https://github.com/chubbyphp/chubbyphp-container. There is a migration guide at: https://github.com/chubbyphp/chubbyphp-container/blob/master/doc/MigrateFromPimple.md

It may be a shameless pull request, but as far as i am aware of the alternatives to pimple there is no one that is not much bigger and more complex than Pimple. So i had to try.

Regards Dominik