### PR TITLE
Implement psr/container 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.0"
+        "psr/container": "^1.1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0"

--- a/src/Pimple/Psr11/Container.php
+++ b/src/Pimple/Psr11/Container.php
@@ -43,12 +43,12 @@ final class Container implements ContainerInterface
         $this->pimple = $pimple;
     }
 
-    public function get($id)
+    public function get(string $id)
     {
         return $this->pimple[$id];
     }
 
-    public function has($id)
+    public function has(string $id): bool
     {
         return isset($this->pimple[$id]);
     }

--- a/src/Pimple/Psr11/ServiceLocator.php
+++ b/src/Pimple/Psr11/ServiceLocator.php
@@ -56,7 +56,7 @@ class ServiceLocator implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!isset($this->aliases[$id])) {
             throw new UnknownIdentifierException($id);
@@ -68,7 +68,7 @@ class ServiceLocator implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($id)
+    public function has(string $id)
     {
         return isset($this->aliases[$id]) && isset($this->container[$this->aliases[$id]]);
     }


### PR DESCRIPTION
This PR proposes to upgrade Pimple's PSR-11 implementation with parameter type declarations from `psr/container` 1.1.

Since the `Container` class is `final`, I have also added a return type to the `has()` method as a preparation for version 2 of the interfaces. Unfortunately, the `ServiceLocator` class is not final, so I could not add the return type here as that would be a BC break. If I'm not mistaken, this would be the only change necessary for `psr/container` 2.