### PR TITLE
Run the tests on PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 phpunit.xml
+.phpunit.result.cache
 composer.lock
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - nightly
 
 before_script:


### PR DESCRIPTION
The test suite is currently run on PHP 7.2, 7.3, 7.4 and 8.1-dev (`nightly`). I think it should be run on PHP 8.0 too, which is the current stable PHP release.