### PR TITLE
Add PSR11 Wrapper Convenience Method

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -295,4 +295,15 @@ class Container implements \ArrayAccess
 
         return $this;
     }
+
+  /**
+   * Convenience method for supplying a PSR-11 compliant container to libraries and frameworks
+   *
+   * @return \Pimple\Psr11\Container
+   */
+    public function toPsr11() {
+
+      return new Psr11\Container($this);
+
+    }
 }


### PR DESCRIPTION
Hi! Our team loves Pimple with a passion. We've recently started using more libraries that contract against PSR-11 containers. We end up wrapping the Pimple container at the call site in a new instance of the `Psr11\Container` but this proposed change would allow us to just pass in `$container->toPsr11()` without our implementations having to be aware or coupled to that `Psr11\Container` class at all. 

I'd imagine as the spec is adopted further in other libraries this could be more useful as time goes on. 

I know the goal of this library is to stay small and trim, so I completely understand if it's not a worthwhile addition. Thanks for all your hard work on it over the years. It's the backbone of many great apps!