### PR TITLE
proposal: update examples with short functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,13 +52,9 @@ object:
 .. code-block:: php
 
     // define some services
-    $container['session_storage'] = function ($c) {
-        return new SessionStorage('SESSION_ID');
-    };
+    $container['session_storage'] = fn($c) => new SessionStorage('SESSION_ID');
 
-    $container['session'] = function ($c) {
-        return new Session($c['session_storage']);
-    };
+    $container['session'] = fn($c) => new Session($c['session_storage']);
 
 Notice that the anonymous function has access to the current container
 instance, allowing references to other services or parameters.
@@ -86,9 +82,7 @@ anonymous function with the ``factory()`` method
 
 .. code-block:: php
 
-    $container['session'] = $container->factory(function ($c) {
-        return new Session($c['session_storage']);
-    });
+    $container['session'] = $container->factory(fn($c) => new Session($c['session_storage']);
 
 Now, each call to ``$container['session']`` returns a new instance of the
 session.
@@ -109,9 +103,7 @@ If you change the ``session_storage`` service definition like below:
 
 .. code-block:: php
 
-    $container['session_storage'] = function ($c) {
-        return new $c['session_storage_class']($c['cookie_name']);
-    };
+    $container['session_storage'] = fn($c) => new $c['session_storage_class']($c['cookie_name']);
 
 You can now easily change the cookie name by overriding the
 ``cookie_name`` parameter instead of redefining the service
@@ -126,9 +118,7 @@ parameters:
 
 .. code-block:: php
 
-    $container['random_func'] = $container->protect(function () {
-        return rand();
-    });
+    $container['random_func'] = $container->protect(fn() => rand());
 
 Modifying Services after Definition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -139,9 +129,7 @@ run on your service just after it is created:
 
 .. code-block:: php
 
-    $container['session_storage'] = function ($c) {
-        return new $c['session_storage_class']($c['cookie_name']);
-    };
+    $container['session_storage'] = fn($c) => new $c['session_storage_class']($c['cookie_name']);
 
     $container->extend('session_storage', function ($storage, $c) {
         $storage->...();
@@ -187,9 +175,7 @@ raw access to this function, you can use the ``raw()`` method:
 
 .. code-block:: php
 
-    $container['session'] = function ($c) {
-        return new Session($c['session_storage']);
-    };
+    $container['session'] = fn($c) => new Session($c['session_storage']);
 
     $sessionFunction = $container->raw('session');
 
@@ -213,9 +199,7 @@ methods:
     use Pimple\Psr11\Container as PsrContainer;
 
     $container = new Container();
-    $container['service'] = function ($c) {
-        return new Service();
-    };
+    $container['service'] = fn($c) => new Service();
     $psr11 = new PsrContainer($container);
 
     $controller = function (PsrContainer $container) {
@@ -265,13 +249,9 @@ registered under the name ``dispatcher``:
         }
     }
 
-    $container['logger'] = function ($c) {
-        return new Monolog\Logger();
-    };
-    $container['dispatcher'] = function () {
-        return new EventDispatcher();
-    };
-
+    $container['logger'] = fn($c) => new Monolog\Logger();
+    $container['dispatcher'] = fn($c) => new EventDispatcher();
+    
     $container['service'] = function ($c) {
         $locator = new ServiceLocator($c, array('logger', 'event_dispatcher' => 'dispatcher'));
 
@@ -319,14 +299,8 @@ when iterated over:
 
     $container = new Container();
 
-    $container['voter1'] = function ($c) {
-        return new SomeVoter();
-    }
-    $container['voter2'] = function ($c) {
-        return new SomeOtherVoter($c['auth']);
-    }
-    $container['auth'] = function ($c) {
-        return new AuthorizationService(new ServiceIterator($c, array('voter1', 'voter2'));
-    }
+    $container['voter1'] = fn($c) => new SomeVoter();
+    $container['voter2'] = fn($c) => new SomeOtherVoter($c['auth']);
+    $container['auth'] = fn ($c) => new AuthorizationService(new ServiceIterator($c, array('voter1', 'voter2'));
 
 .. _Pimple 1.x documentation: https://github.com/silexphp/Pimple/tree/1.1


### PR DESCRIPTION
I think showing the short function syntax in the examples might improve the clarity of the examples because there is less visual bloat for the eye to process.

I you don't agree, just close the PR, no worries.