### PR TITLE
Fixes php 8.5 deprecated methods SplObjectStorage::attach() and SplObjectStorage::detach()

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -196,7 +196,7 @@ class Container implements \ArrayAccess
             throw new ExpectedInvokableException('Callable is not a Closure or invokable object.');
         }
 
-        $this->protected->attach($callable);
+        $this->protected->offsetSet($callable);
 
         return $callable;
     }
@@ -268,8 +268,8 @@ class Container implements \ArrayAccess
         };
 
         if (isset($this->factories[$factory])) {
-            $this->factories->detach($factory);
-            $this->factories->attach($extended);
+            $this->factories->offsetUnset($factory);
+            $this->factories->offsetSet($extended);
         }
 
         return $this[$id] = $extended;


### PR DESCRIPTION
In addition to #276

Fixes `SplObjectStorage` deprecated methods since php 8.5
- `attach()` is replaced by `offsetSet()`
- `detach()` is replaced by `offsetUnset()`
